### PR TITLE
Replaced gulp-util with new packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "bufferstreams": "^1.1.0",
-    "gulp-util": "^3.0.7",
     "plugin-error": "^1.0.1",
     "readable-stream": "^2.0.4",
     "replace-ext": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,13 @@
     "cli": "env NPM_RUN_CLI=1"
   },
   "dependencies": {
-    "ttf2woff2": "^2.0.3",
-    "gulp-util": "^3.0.7",
     "bufferstreams": "^1.1.0",
-    "readable-stream": "^2.0.4"
+    "gulp-util": "^3.0.7",
+    "plugin-error": "^1.0.1",
+    "readable-stream": "^2.0.4",
+    "replace-ext": "^1.0.0",
+    "ttf2woff2": "^2.0.3",
+    "vinyl": "^2.2.0"
   },
   "keywords": [
     "gulpplugin",

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,10 @@
 
 var path = require('path');
 var Stream = require('readable-stream');
-var gutil = require('gulp-util');
 var BufferStreams = require('bufferstreams');
 var ttf2woff2 = require('ttf2woff2');
+var PluginError = require('plugin-error');
+var replaceExtension = require('replace-ext');
 
 var PLUGIN_NAME = 'gulp-ttf2woff2';
 
@@ -15,7 +16,7 @@ function ttf2woff2Transform() {
 
     // Handle any error
     if(err) {
-      return cb(new gutil.PluginError(PLUGIN_NAME, err, { showStack: true }));
+      return cb(new PluginError(PLUGIN_NAME, err, { showStack: true }));
     }
 
     // Use the buffered content
@@ -23,7 +24,7 @@ function ttf2woff2Transform() {
       buf = ttf2woff2(buf);
       return cb(null, buf);
     } catch(err2) {
-      return cb(new gutil.PluginError(PLUGIN_NAME, err2, { showStack: true }));
+      return cb(new PluginError(PLUGIN_NAME, err2, { showStack: true }));
     }
 
   };
@@ -68,14 +69,14 @@ function ttf2woff2Gulp(options) {
       }
     }
 
-    file.path = gutil.replaceExtension(file.path, '.woff2');
+    file.path = replaceExtension(file.path, '.woff2');
 
     // Buffers
     if(file.isBuffer()) {
       try {
         file.contents = ttf2woff2(file.contents);
       } catch(err) {
-        stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err, {
+        stream.emit('error', new PluginError(PLUGIN_NAME, err, {
           showStack: true,
         }));
       }

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -3,10 +3,10 @@
 'use strict';
 
 var gulp = require('gulp');
-var gutil = require('gulp-util');
 var Stream = require('stream');
 var fs = require('fs');
 var path = require('path');
+var Vinyl = require('vinyl');
 
 var assert = require('assert');
 var StreamTest = require('streamtest');
@@ -26,7 +26,7 @@ describe('gulp-ttf2woff2 conversion', function() {
 
         it('should let null files pass through', function(done) {
 
-          StreamTest[version].fromObjects([new gutil.File({
+          StreamTest[version].fromObjects([new Vinyl({
             path: 'bibabelula.foo',
             contents: null,
           })])
@@ -91,7 +91,7 @@ describe('gulp-ttf2woff2 conversion', function() {
 
         it('should let non-ttf files pass through', function(done) {
 
-          StreamTest[version].fromObjects([new gutil.File({
+          StreamTest[version].fromObjects([new Vinyl({
             path: 'bibabelula.foo',
             contents: new Buffer('ohyeah'),
           })])
@@ -162,7 +162,7 @@ describe('gulp-ttf2woff2 conversion', function() {
 
         it('should let non-ttf files pass through', function(done) {
 
-          StreamTest[version].fromObjects([new gutil.File({
+          StreamTest[version].fromObjects([new Vinyl({
             path: 'bibabelula.foo',
             contents: new Stream.PassThrough(),
           })])
@@ -173,7 +173,7 @@ describe('gulp-ttf2woff2 conversion', function() {
             }
             assert.equal(objs.length, 1);
             assert.equal(objs[0].path, 'bibabelula.foo');
-            assert(objs[0].contents instanceof Stream.PassThrough);
+            assert(objs[0].contents._original instanceof Stream.PassThrough);
             done();
           }));
 


### PR DESCRIPTION
`gulp-util` has been deprecated a while ago. https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5

This PR replaces it with packages suggested by the gulpjs team. There is zero changes to the API and some small changes in the tests.
