### PR TITLE
Add support for Node.js 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 4.0
+  - 12
 
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "plugin-error": "^1.0.1",
     "readable-stream": "^2.0.4",
     "replace-ext": "^1.0.0",
-    "ttf2woff2": "^2.0.3",
+    "ttf2woff2": "^3.0.0",
     "vinyl": "^2.2.0"
   },
   "keywords": [
@@ -48,7 +48,7 @@
     "coveralls": "^2.11.4",
     "eslint": "^1.10.1",
     "eslint-config-simplifield": "^1.1.0",
-    "gulp": "^3.9.0",
+    "gulp": "^4.0.2",
     "istanbul": "^0.4.0",
     "mocha": "^2.3.4",
     "mocha-lcov-reporter": "^1.0.0",


### PR DESCRIPTION
Following https://github.com/nfroidure/ttf2woff2/pull/51, I just published [ttf2woff2@3.0.0](https://www.npmjs.com/package/ttf2woff2). I am updating also the Gulp dependency since it's not compatible with Node 12 (https://github.com/gulpjs/gulp/issues/2324).

As with ttf2woff2 package, I'll be happy to help with all the chores 🙌 