### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+on: push
+name: Run tests
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [4, 12]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - 4.0
-  - 12
-
-script:
-  - npm test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gulp-ttf2woff2
 > Create a WOFF2 font from a TTF font with [Gulp](http://gulpjs.com/).
 
-[![NPM version](https://badge.fury.io/js/gulp-ttf2woff2.svg)](https://npmjs.org/package/gulp-ttf2woff2) [![Build status](https://secure.travis-ci.org/nfroidure/gulp-ttf2woff2.svg)](https://travis-ci.org/nfroidure/gulp-ttf2woff2) [![Dependency Status](https://david-dm.org/nfroidure/gulp-ttf2woff2.svg)](https://david-dm.org/nfroidure/gulp-ttf2woff2) [![devDependency Status](https://david-dm.org/nfroidure/gulp-ttf2woff2/dev-status.svg)](https://david-dm.org/nfroidure/gulp-ttf2woff2#info=devDependencies) [![Coverage Status](https://coveralls.io/repos/nfroidure/gulp-ttf2woff2/badge.svg?branch=master)](https://coveralls.io/r/nfroidure/gulp-ttf2woff2?branch=master) [![Code Climate](https://codeclimate.com/github/nfroidure/gulp-ttf2woff2.svg)](https://codeclimate.com/github/nfroidure/gulp-ttf2woff2)
+[![NPM version](https://badge.fury.io/js/gulp-ttf2woff2.svg)](https://npmjs.org/package/gulp-ttf2woff2) [![Run test](https://github.com/nfroidure/gulp-ttf2woff2/workflows/Run%20tests/badge.svg)](https://github.com/nfroidure/gulp-ttf2woff2/actions) [![Dependency Status](https://david-dm.org/nfroidure/gulp-ttf2woff2.svg)](https://david-dm.org/nfroidure/gulp-ttf2woff2) [![devDependency Status](https://david-dm.org/nfroidure/gulp-ttf2woff2/dev-status.svg)](https://david-dm.org/nfroidure/gulp-ttf2woff2#info=devDependencies) [![Coverage Status](https://coveralls.io/repos/nfroidure/gulp-ttf2woff2/badge.svg?branch=master)](https://coveralls.io/r/nfroidure/gulp-ttf2woff2?branch=master) [![Code Climate](https://codeclimate.com/github/nfroidure/gulp-ttf2woff2.svg)](https://codeclimate.com/github/nfroidure/gulp-ttf2woff2)
 
 ## Usage
 


### PR DESCRIPTION
The new pricing plan on Travis is less generous. I thought that Linux build would still be completely free 🤔 

![image](https://user-images.githubusercontent.com/3654180/104747072-07ed6080-578b-11eb-8529-08b985e476c7.png)

Anyway, I don't really want to dig into that. GitHub Actions is an excellent alternative: free for OSS, better solution for managing permissions, better support of forks, etc.

The CI is relatively simple in this repository, so I will just migrate to GH Actions.