### PR TITLE
Update Node test matrix (remove 16/18/19, add 22/23/24)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22, 23, 24]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Proposed changes

I am updating the Node versions used for running tests. We will likely bump a major version for the next release because I plan to include https://github.com/nfroidure/ttf2woff2/commit/3a9b14734fe166d3f7db65d8d8407a7f08540da5. So I will take this opportunity to include more changes (using ESM, updating dependencies).

![image](https://github.com/user-attachments/assets/db551248-5c41-44fc-8069-536c55712588)

